### PR TITLE
Remove the need for mandatory choices parameters as it does not work …

### DIFF
--- a/lib/client_side_validations/action_view/form_builder.rb
+++ b/lib/client_side_validations/action_view/form_builder.rb
@@ -68,7 +68,7 @@ module ClientSideValidations
           radio_button_without_client_side_validations(method, tag_value, options)
         end
 
-        def select_with_client_side_validations(method, choices, options = {}, html_options = {}, &block)
+        def select_with_client_side_validations(method, choices = nil, options = {}, html_options = {}, &block)
           build_validation_options(method, html_options.merge(name: options[:name]))
           html_options.delete(:validate)
           select_without_client_side_validations(method, choices, options, html_options, &block)


### PR DESCRIPTION
…in block mode.

When using with administrate, you get the following error:

```
ActionView::Template::Error (wrong number of arguments (given 1, expected 2..4)):
    20:   <%= f.label field.permitted_attribute %>
    21: </div>
    22: <div class="field-unit__field">
    23:   <%= f.select(field.permitted_attribute) do %>
    24:     <%= options_for_select(field.associated_resource_options, field.selected_option) %>
    25:   <% end %>
    26: </div>
  client_side_validations (4.2.3) lib/client_side_validations/action_view/form_builder.rb:71:in `select_with_client_side_validations'
  /usr/local/Cellar/rbenv/1.0.0/versions/2.3.1/lib/ruby/gems/2.3.0/gems/administrate-0.2.2/app/views/fields/belongs_to/_form.html.erb:23:in `__usr_local__ellar_rbenv_______versions_______lib_ruby_gems_______gems_administrate_______app_views_fields_belongs_to__form_html_erb__3134659838160025824_70245171529640'
  actionview (4.2.6) lib/action_view/template.rb:145:in `block in render'
```

Made `choices` an optional parameter.
